### PR TITLE
chore: ignore macOS metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,4 @@ go.work.sum
 AGENTS.md
 SPEC.md
 PROPOSED.md
+.DS_Store


### PR DESCRIPTION
Adds a repository-wide `.DS_Store` ignore rule so Finder metadata no longer appears in working trees or future commits.